### PR TITLE
Fix Helicowpter cow

### DIFF
--- a/cows.txt
+++ b/cows.txt
@@ -3533,7 +3533,6 @@ cow who cow'nts
   //`---\/||
   ||      ||
 
-
   Helicowpter
 
 


### PR DESCRIPTION
Currently "Helicowpter" is shown as a standalone text instead of being shown together with the ASCII art, this fixes it.